### PR TITLE
Fix script tag in index template

### DIFF
--- a/views/index.hbs
+++ b/views/index.hbs
@@ -6,6 +6,6 @@
 </head>
 <body>
     <div id="quiz"/>
-    <script type="text/javascript" src="/build/bundle.js"/>
+    <script type="text/javascript" src="/build/bundle.js"></script>
 </body>
 </html>


### PR DESCRIPTION
Fixes #1

Unlike some other html elements, script tags cannot be self-closing. This was preventing your script from loading